### PR TITLE
WIP: Redo robot registration

### DIFF
--- a/services/infodb/init.sql
+++ b/services/infodb/init.sql
@@ -5,5 +5,5 @@ CREATE TABLE robots (
     registeredUserId text
 );
 
-INSERT INTO robots (serial, nickname, robotType, registeredUserId) VALUES ('123abc', 'testLightbot', 'switch', '1');
-INSERT INTO robots (serial, nickname, robotType, registeredUserId) VALUES ('qwerty', 'testThermoBot', 'thermostat', '1');
+INSERT INTO robots (serial) VALUES ('123abc');
+INSERT INTO robots (serial) VALUES ('qwerty');

--- a/services/infoserver/main.go
+++ b/services/infoserver/main.go
@@ -173,7 +173,13 @@ func (s *server) RegisterRobot(ctx context.Context, query *infoserver.RegisterRo
 	}
 
 	// update robot
-	_, err = s.DB.Exec("UPDATE robots SET nickname = $1, robotType = $2, registeredUserId = $3 WHERE serial = $4", query.Nickname, query.RobotType, query.UserId, query.Id)
+	_, err = s.DB.Exec(
+		"UPDATE robots SET nickname = $1, robotType = $2, registeredUserId = $3 WHERE serial = $4",
+		query.Nickname,
+		query.RobotType,
+		query.UserId,
+		query.Id,
+	)
 	if err != nil {
 		log.Printf("failed to update robots: %v", err)
 		return nil, status.New(codes.Internal, "internal error").Err()

--- a/services/infoserver/main.go
+++ b/services/infoserver/main.go
@@ -127,16 +127,18 @@ func (s *server) GetRobots(query *infoserver.RobotsQuery, stream infoserver.Info
 			log.Printf("Failed to scan row of robots table: %v", err)
 			return err
 		}
+
 		if robotType == robotTypeSwitch {
 			interfaceType = "toggle"
 		} else {
 			interfaceType = "range"
 		}
+
 		err = stream.Send(&infoserver.Robot{
 			Id:            serial,
 			Nickname:      nickname,
 			RobotType:     robotType,
-			InterfaceType: interfaceType, // what should this be? used to be "toggle" or "range"
+			InterfaceType: interfaceType,
 		})
 		if err != nil {
 			return err
@@ -146,26 +148,35 @@ func (s *server) GetRobots(query *infoserver.RobotsQuery, stream infoserver.Info
 }
 
 func (s *server) RegisterRobot(ctx context.Context, query *infoserver.RegisterRobotQuery) (*empty.Empty, error) {
-	log.Println("registering robot")
-	rows, err := s.DB.Query("SELECT * FROM robots WHERE serial = $1", query.Id)
-	if err != nil {
-		log.Println("Failed to search database for robot.")
-		return nil, err
-	}
-	for rows.Next() {
-		return nil, status.Newf(codes.AlreadyExists, "Robot \"%s\" already exists", query.Id).Err()
-	}
+	log.Printf("registering robot \"%s\"", query.Id)
+	row := s.DB.QueryRow("SELECT serial, nickname, robotType, registeredUserId FROM robots WHERE serial = $1", query.Id)
 
-	_, err = s.DB.Exec(
-		"INSERT INTO robots (serial, nickname, robotType, registeredUserId) VALUES ($1, $2, $3, $4)",
-		query.Id,
-		query.Nickname,
-		query.RobotType,
-		query.UserId,
+	// get robot
+	var (
+		serial           string
+		nickname         *string
+		robotType        *string
+		registeredUserID *string
 	)
-
+	err := row.Scan(&serial, &nickname, &robotType, &registeredUserID)
 	if err != nil {
-		return nil, err
+		if err == sql.ErrNoRows {
+			return nil, status.Newf(codes.NotFound, "robot \"%s\" does not exist", query.Id).Err()
+		}
+		log.Printf("error scanning robots: %v", err)
+		return nil, status.New(codes.Internal, "internal error").Err()
+	}
+
+	// check robot is not registerd
+	if registeredUserID != nil {
+		return nil, status.New(codes.FailedPrecondition, "robot \"%s\" has already been registered").Err()
+	}
+
+	// update robot
+	_, err = s.DB.Exec("UPDATE robots SET nickname = $1, robotType = $2, registeredUserId = $3 WHERE serial = $4", query.Nickname, query.RobotType, query.UserId, query.Id)
+	if err != nil {
+		log.Printf("failed to update robots: %v", err)
+		return nil, status.New(codes.Internal, "internal error").Err()
 	}
 
 	return &empty.Empty{}, nil

--- a/services/infoserver/main_test.go
+++ b/services/infoserver/main_test.go
@@ -210,7 +210,7 @@ func TestGetRobots(t *testing.T) {
 
 	client := infoserver.NewInfoServerClient(conn)
 
-	client.RegisterRobot(ctx, &infoserver.RegisterRobotQuery{
+	_, err = client.RegisterRobot(ctx, &infoserver.RegisterRobotQuery{
 		Id:        "123abc",
 		Nickname:  "testLightbot",
 		RobotType: "switch",
@@ -288,7 +288,7 @@ func TestGetRobotWithValidID(t *testing.T) {
 
 		client := infoserver.NewInfoServerClient(conn)
 
-		client.RegisterRobot(ctx, &infoserver.RegisterRobotQuery{
+		_, err = client.RegisterRobot(ctx, &infoserver.RegisterRobotQuery{
 			Id:        "123abc",
 			Nickname:  "testLightbot",
 			RobotType: "switch",

--- a/services/switchdb/init.sql
+++ b/services/switchdb/init.sql
@@ -10,5 +10,3 @@ CREATE TABLE switches (
     -- Weather the robot has been calibrated
     isCalibrated boolean not null
 );
-
-INSERT INTO switches (serial, isOn, onAngle, offAngle, restAngle, isCalibrated) VALUES ('123abc', false, 90, 0, 45, true);


### PR DESCRIPTION
It has just occurred to me, the way we have it set up at the moment is that the robot ID matches to a specific use case (123abc for switch and qwerty for thermostat), whereas we want a robot ID to be configured to do any of these use cases (because the ID is the HAL not the PAL). 

- [x] refactor `RegisterRobot`
- [ ] refactor `AddSwitch` / `RemoveSwitch`
- [ ] add `AddThermostat` / `RemoveThermostat`
- [ ] create `UnregisterRobot`